### PR TITLE
Update README with codebase overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,35 @@
 # doorbot_1.3
 DoorBot 1.3 consisting of a Raspberry Pi 2 and custom made DoorBot v1.3 shield
 
+## Codebase Overview
+
+The project is an asynchronous Slack bot that controls hardware on a Raspberry Pi. The main entry point is `doorbot/app.py`, which sets up logging, loads configuration, and starts hardware interfaces. It defines Slack bot actions for unlocking the door, sending messages, and other operations.
+
+### General Structure
+
+- `doorbot/app.py` – main async application launched via `python -m doorbot`. It handles logging, configuration, hardware interfaces and defines Slack actions.
+- `doorbot/interfaces/` – hardware and API interfaces such as:
+  - `doorbot_hat_gpio.py` for controlling the DoorBot hat relays and inputs via `pigpio`.
+  - `wiegand_key_reader.py` and `wiegand.py` for reading RFID/NFC cards.
+  - `blinkstick_interface.py` to drive the BlinkStick LED strip.
+  - `tidyauth_client.py` and `user_manager.py` for fetching authorised keys.
+  - `sound_downloader.py`, `sound_player.py`, and `text_to_speech.py` for audio playback and TTS.
+  - `slack_blocks.py` containing Slack BlockKit payloads.
+- `doorbot/utils/` – miscellaneous scripts such as `convert_old_rfid_key.py` or `name_association.py`.
+- `speaker_server.py` – optional Flask server exposing simple `/speak` and `/play_mp3_base64` endpoints.
+- `experiments/` and `doorbot/tests/` – test scripts and hardware demos.
+- `config.json.template` – example configuration with tokens, Slack channels, and TidyAuth settings.
+
+### Pointers for Learning
+
+- Explore Slack Bolt usage in `app.py` and the BlockKit layouts in `slack_blocks.py`.
+- Check out hardware interfaces (`doorbot_hat_gpio.py`, `wiegand_key_reader.py`) and review the schematics under `schematics/`.
+- Understand how `tidyauth_client.py` and `user_manager.py` manage authorised keys.
+- Look into the audio helpers for VLC playback and text-to-speech.
+- Review `doorbot.service` and `speaker_server.service` for deployment as systemd services.
+- Logging is sent to Slack via a custom handler in `app.py`.
+- From here you might delve deeper into Slack Bolt features, pigpio for advanced hardware interaction, or experiment with new Slack actions and home tab views.
+
 ## Installation
 
 Install this package for TTS:


### PR DESCRIPTION
## Summary
- provide a new **Codebase Overview** section in the README
  - introduce the structure of the application
  - include tips for learning more about the project

## Testing
- `pytest -q` *(fails: the tests expect command-line arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6840313e898083259bccf5787a0cd4bc